### PR TITLE
raise errors if numpy not present but functions that call it are called

### DIFF
--- a/pycl.py
+++ b/pycl.py
@@ -119,6 +119,7 @@ from array import array
 try:
     import numpy as np
 except ImportError:
+    np = None
     pass
 
 class cl_sampler(void_p): pass
@@ -2927,6 +2928,9 @@ def buffer_from_ndarray(queue, ary, buf=None, **kw):
     Any additional provided keyword arguments are passed along to
     :func:`clEnqueueWriteBuffer`.
     """
+    if not np:
+        raise Exception("numpy not available")
+
     ary = np.ascontiguousarray(ary)
     if buf is None:
         buf = clCreateBuffer(queue.context, ary.nbytes)
@@ -2963,8 +2967,14 @@ def buffer_to_ndarray(queue, buf, out=None, like=None,
     """
     if out is None:
         if like is not None:
+            if not np:
+                raise Exception("numpy not available")
+
             out = np.empty_like(like)
         else:
+            if not np:
+                raise Exception("numpy not available")
+
             dtype = np.dtype(dtype)
             if shape is None:
                 shape = buf.size // dtype.itemsize

--- a/setup.py
+++ b/setup.py
@@ -1,33 +1,6 @@
 from setuptools import setup
 
-from setuptools.command.sdist import sdist
-from subprocess import Popen, PIPE
-
 from pycl import __version__
-
-class sdist_hg(sdist):
-    user_options = sdist.user_options + [
-            ('dev', None, "Add a dev marker")
-            ]
-
-    def initialize_options(self):
-        sdist.initialize_options(self)
-        self.dev = 0
-
-    def run(self):
-        if self.dev:
-            suffix = '.dev%s' % self.get_revision()
-            self.distribution.metadata.version += suffix
-        sdist.run(self)
-
-    def get_revision(self):
-        try:
-            p = Popen(['hg', 'id', '-i'], stdout=PIPE)
-            rev = p.stdout.read().strip()
-        except:
-            print("Could not determine hg revision.")
-            rev = "deadbeef"
-        return rev
 
 setup(
     name='pycl',
@@ -41,8 +14,7 @@ setup(
     description="OpenCL wrapper using ctypes",
     long_description=open('README.md').read(),
     tests_require=['nose'],
-    cmdclass={'sdist': sdist_hg},
-    classifiers = [
+    classifiers=[
         'Development Status :: 3 - Alpha',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',

--- a/tests.py
+++ b/tests.py
@@ -1,21 +1,27 @@
-from nose.tools import *
 from nose import SkipTest
 from pycl import *
 from array import array
+import abc
 
 try:
     import numpy
-except:
+except ImportError:
     numpy = None
 
 
-class BaseTest:
+class BaseTest(object):
     source = """
     kernel void mxplusb(float m, global float *x, float b, global float *out) {
         int i = get_global_id(0);
         out[i] = m*x[i]+b;
     }
     """
+
+    @abc.abstractmethod
+    def check(self, queue, kernel):
+        """Function that tests data references"""
+        return
+
     def test(self):
         for platform in clGetPlatformIDs():
             context = clCreateContext(platform=platform)
@@ -25,9 +31,12 @@ class BaseTest:
             kernel.argtypes = (cl_float, cl_mem, cl_float, cl_mem)            
             yield self.check, queue, kernel        
 
+
 class TestNumpy(BaseTest):
-    def check(self, queue, kernel ):
-        if not numpy: raise SkipTest
+    def check(self, queue, kernel):
+        if not numpy:
+            raise SkipTest
+
         m = 2
         b = 5
         x = numpy.arange(100, dtype='float32')
@@ -38,10 +47,12 @@ class TestNumpy(BaseTest):
         evt.wait()
         assert(numpy.allclose(y, m*x+b))
 
-def assert_sequence_almost_equal(x, y, tol = 1e-7):
+
+def assert_sequence_almost_equal(x, y, tol=1e-7):
     assert len(x) == len(y), "Lengths not equal"
     for (i, (xi, yi)) in enumerate(zip(x, y)):
         assert abs(xi - yi) < tol, "Sequences differ starting at element %d" % i
+
 
 class TestPyArray(BaseTest):
     def check(self, queue, kernel):
@@ -59,6 +70,9 @@ class TestPyArray(BaseTest):
 
 class TestCopyBuffer(BaseTest):
     def check(self, queue, kernel):
+        if not numpy:
+            raise SkipTest
+
         expected = numpy.arange(10)
         src_buf, evt = buffer_from_ndarray(queue, expected)
         dst_buf, evt = buffer_from_ndarray(queue, numpy.ones_like(expected))


### PR DESCRIPTION
somehow missed some "missing numpy" handling and removed some mercurial stuff from setup.py
