### PR TITLE
Use correct calling convention on Windows.

### DIFF
--- a/pycl.py
+++ b/pycl.py
@@ -881,7 +881,12 @@ if not _dll_filename:
         pass
 if _dll_filename:
     try:
-        _dll = ctypes.cdll.LoadLibrary(_dll_filename)
+        if hasattr(ctypes, 'windll'):
+            # Assume that the presence of ctypes.windll indicates we're on Windows.
+            # In this case, we must use the stdcall calling convention.
+            _dll = ctypes.windll.LoadLibrary(_dll_filename)
+        else:
+            _dll = ctypes.cdll.LoadLibrary(_dll_filename)
     except:
         raise RuntimeError('Could not load OpenCL dll: %s' % _dll_filename)
 else:


### PR DESCRIPTION
OpenCL.dll uses stdcall calling convention ([source](https://forums.khronos.org/showthread.php/6299-OpenCL-ICD-infrastructure-questions)), which means we need ctypes.windll instead of ctypes.cdll on Windows.

Verified that this fix works on Windows 10 with nVidia OpenCL library. Without this patch, I get

```
    clGetPlatformIDs.call(0, None, byref(num_platforms))
ValueError: Procedure called with not enough arguments (12 bytes missing) or wrong calling convention
```
